### PR TITLE
Update php-coding-standards version for dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "phpmd/phpmd": "*",
     "phpmetrics/phpmetrics": "*",
     "sebastian/phpcpd": "*",
-    "degordian/php-coding-standards": "dev-master",
+    "degordian/php-coding-standards": "1.0.4.1",
     "flow/jsonpath": "*",
     "phploc/phploc": "*",
     "pdepend/pdepend": "*",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "phpmd/phpmd": "*",
     "phpmetrics/phpmetrics": "*",
     "sebastian/phpcpd": "*",
-    "degordian/php-coding-standards": "1.0.4.1",
+    "degordian/php-coding-standards": "^1.0",
     "flow/jsonpath": "*",
     "phploc/phploc": "*",
     "pdepend/pdepend": "*",


### PR DESCRIPTION
degordian/php-coding-standards has a release tagged with a version
number, so testing-toolkit should use the latest stable version as
it's dependency.

I'm not sure if degordian/php-coding-standards v1.0.4.1 adheres to SemVer, so I'm using explicit version number here (not sure how Composer would handle versions constraints in this case).